### PR TITLE
Fix compatibility with python3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ python:
  - "3.6-dev"
  - "nightly"
 
+matrix:
+  allow_failures:
+  - python: "nightly"
+
 install:
  - "python setup.py install"
 

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(name='TakeTheTime',
       url='https://github.com/ErikBjare/TakeTheTime',
       packages=['takethetime'],
       install_requires=[
-          'typing'
+          'typing;python_version<"3.5"'
       ])


### PR DESCRIPTION
Breaks aw-server completely for me without this fix.
Typing is pre-installed in python3.7 and installing the pypi version creates errors.